### PR TITLE
Add a tracing interface

### DIFF
--- a/tracing/newrelic/go.mod
+++ b/tracing/newrelic/go.mod
@@ -1,0 +1,5 @@
+module github.com/omegaup/go-base/v2/tracing/newrelic
+
+go 1.17
+
+require github.com/newrelic/go-agent v3.15.1+incompatible // indirect

--- a/tracing/newrelic/go.sum
+++ b/tracing/newrelic/go.sum
@@ -1,0 +1,2 @@
+github.com/newrelic/go-agent v3.15.1+incompatible h1:nwDldxhCgxr3yDnMZE4v0lbWnHJ08hVcU517HdxMDeU=
+github.com/newrelic/go-agent v3.15.1+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=

--- a/tracing/newrelic/newrelic.go
+++ b/tracing/newrelic/newrelic.go
@@ -1,0 +1,84 @@
+package newrelic
+
+import (
+	"net/http"
+
+	"github.com/omegaup/go-base/v2/tracing"
+
+	nr "github.com/newrelic/go-agent/v3/newrelic"
+)
+
+type provider struct {
+	app *nr.Application
+}
+
+// New returns a new tracing.Provider that can interact with New Relic.
+func New(app *nr.Application) tracing.Provider {
+	return &provider{
+		app: app,
+	}
+}
+
+func (p *provider) StartTransaction(name string, args ...tracing.Arg) tracing.Transaction {
+	txn := &transaction{txn: p.app.StartTransaction(name)}
+	txn.AddAttributes(args...)
+	return txn
+}
+
+func (p *provider) StartWebTransaction(name string, w http.ResponseWriter, r *http.Request, args ...tracing.Arg) (tracing.Transaction, http.ResponseWriter, *http.Request) {
+	txn := p.StartTransaction(name, args...).(*transaction)
+
+	txn.txn.SetWebRequestHTTP(r)
+	w = txn.txn.SetWebResponse(w)
+	r = r.WithContext(tracing.NewContext(r.Context(), txn))
+
+	return txn, w, r
+}
+
+func (p *provider) WrapHandle(pattern string, handler http.Handler) (string, http.Handler) {
+	if p.app == nil {
+		return pattern, handler
+	}
+	return pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var txn tracing.Transaction
+		txn, w, r = p.StartWebTransaction(r.Method+" "+pattern, w, r)
+		defer txn.End()
+
+		handler.ServeHTTP(w, r)
+	})
+}
+
+type transaction struct {
+	txn *nr.Transaction
+}
+
+func (t *transaction) SetName(name string) {
+	t.txn.SetName(name)
+}
+
+func (t *transaction) AddAttributes(args ...tracing.Arg) {
+	for _, arg := range args {
+		t.txn.AddAttribute(arg.Name, arg.Value)
+	}
+}
+
+func (t *transaction) StartSegment(name string) tracing.Segment {
+	s := nr.StartSegment(t.txn, name)
+	return &segment{s: s}
+}
+
+func (t *transaction) NoticeError(err error) {
+	t.txn.NoticeError(err)
+}
+
+func (t *transaction) End() {
+	t.txn.End()
+}
+
+type segment struct {
+	s *nr.Segment
+}
+
+func (s *segment) End() {
+	s.s.End()
+}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,121 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+)
+
+type key int
+
+var transactionKey key
+
+// An Arg represents a name-value pair.
+type Arg struct {
+	Name  string
+	Value interface{}
+}
+
+// A Segment is a part of a transaction used to instrument
+// functions, methods, and blocks of code.
+type Segment interface {
+	// End marks the segment as finished.
+	End()
+}
+
+// A Transaction represents one logical unit of work: either an
+// inbound web request or background task.
+type Transaction interface {
+	// SetName sets the current transaction's name.
+	SetName(name string)
+
+	// AddAttributes adds any attributes after the transaction was created.
+	AddAttributes(args ...Arg)
+
+	// StartSegment creates a new Segment inside the transaction.
+	StartSegment(name string) Segment
+
+	// NoticeError associates an error with the transaction.
+	NoticeError(err error)
+
+	// End marks the transaction as finished.
+	End()
+}
+
+// Provider is the interface that can create Transactions.
+type Provider interface {
+	// StartTransaction starts a new Transaction with the provided name and
+	// arguments.
+	StartTransaction(name string, args ...Arg) Transaction
+
+	// StartWebTransaction starts a new web Transaction with the provided name
+	// and arguments.
+	StartWebTransaction(
+		name string,
+		w http.ResponseWriter,
+		r *http.Request,
+		args ...Arg,
+	) (Transaction, http.ResponseWriter, *http.Request)
+
+	// WrapHandle is a convenience function for wrapping an http.Handler and
+	// adding all necessary tracing information.
+	WrapHandle(pattern string, handler http.Handler) (string, http.Handler)
+}
+
+// NewContext associates the transaction with the provided context.
+// FromContext can then be used to retrieve the transaction.
+func NewContext(ctx context.Context, txn Transaction) context.Context {
+	return context.WithValue(ctx, transactionKey, txn)
+}
+
+// FromContext returns the current Transaction associated with the Context.
+func FromContext(ctx context.Context) Transaction {
+	if ctx == nil {
+		return &noopTransaction{}
+	}
+	txn, ok := ctx.Value(transactionKey).(Transaction)
+	if !ok {
+		return &noopTransaction{}
+	}
+
+	return txn
+}
+
+type noopProvider struct{}
+
+// NewNoOpProvider returns a new provider that does nothing.
+func NewNoOpProvider() Provider {
+	return &noopProvider{}
+}
+
+func (p *noopProvider) StartTransaction(name string, args ...Arg) Transaction {
+	return &noopTransaction{}
+}
+func (p *noopProvider) StartWebTransaction(name string, w http.ResponseWriter, r *http.Request, args ...Arg) (Transaction, http.ResponseWriter, *http.Request) {
+	return &noopTransaction{}, w, r
+}
+func (p *noopProvider) TransactionFromContext(ctx context.Context) Transaction {
+	return NewNoOpTransaction()
+}
+func (p *noopProvider) WrapHandle(pattern string, handler http.Handler) (string, http.Handler) {
+	return pattern, handler
+}
+
+type noopTransaction struct{}
+
+// NewNoOpTransaction returns a Transaction that does nothing. Useful for tests.
+func NewNoOpTransaction() Transaction {
+	return &noopTransaction{}
+}
+
+func (t *noopTransaction) SetName(name string)       {}
+func (t *noopTransaction) AddAttributes(args ...Arg) {}
+func (t *noopTransaction) StartSegment(name string) Segment {
+	return &noopSegment{}
+}
+func (t *noopTransaction) NoticeError(err error) {}
+func (t *noopTransaction) End()                  {}
+
+type noopSegment struct{}
+
+func (s *noopSegment) AddAttributes(args ...Arg) {}
+func (s *noopSegment) End()                      {}


### PR DESCRIPTION
This change adds a tracing interface, as well as an implementation for
New Relic. This should allow other services to start exposing more
tracing information. #minor