### PR TITLE
Fix the newrelic module's path

### DIFF
--- a/tracing/newrelic/go.mod
+++ b/tracing/newrelic/go.mod
@@ -1,4 +1,4 @@
-module github.com/omegaup/go-base/v2/tracing/newrelic
+module github.com/omegaup/go-base/tracing/newrelic
 
 go 1.17
 


### PR DESCRIPTION
This should make it possible for other modules to import this. #minor