### PR TITLE
Move all log15-related stuff to the new logging/log15 package 

### DIFF
--- a/logging/log15/go.mod
+++ b/logging/log15/go.mod
@@ -1,0 +1,13 @@
+module github.com/omegaup/go-base/logging/log15
+
+go 1.17
+
+require (
+	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/omegaup/go-base/v2 v2.4.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+)

--- a/logging/log15/go.sum
+++ b/logging/log15/go.sum
@@ -1,0 +1,15 @@
+github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
+github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
+github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac h1:n1DqxAo4oWPMvH1+v+DLYlMCecgumhhgnxAPdqDIFHI=
+github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/omegaup/go-base/v2 v2.4.0 h1:A6W4wWf67RLdRhQNL8oB4YpoHlQ1rsYONL+RmDA4DSc=
+github.com/omegaup/go-base/v2 v2.4.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/logging/log15/log15.go
+++ b/logging/log15/log15.go
@@ -1,0 +1,142 @@
+package log15
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/go-stack/stack"
+	log "github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+
+	"github.com/omegaup/go-base/v2/logging"
+)
+
+type log15Logger struct {
+	l log.Logger
+}
+
+var _ logging.Logger = (*log15Logger)(nil)
+
+// Wrap returns a new logging.Logger from an existing log.Logger.
+func Wrap(l log.Logger) logging.Logger {
+	return &log15Logger{l: l}
+}
+
+func (l *log15Logger) Error(msg string, context map[string]interface{}) {
+	l.l.Error(msg, log.Ctx(context))
+}
+
+func (l *log15Logger) Warn(msg string, context map[string]interface{}) {
+	l.l.Warn(msg, log.Ctx(context))
+}
+
+func (l *log15Logger) Info(msg string, context map[string]interface{}) {
+	l.l.Info(msg, log.Ctx(context))
+}
+
+func (l *log15Logger) Debug(msg string, context map[string]interface{}) {
+	l.l.Debug(msg, log.Ctx(context))
+}
+
+func (l *log15Logger) DebugEnabled() bool {
+	// log15 doesn't have a good way of getting the current level.
+	return false
+}
+
+// New opens a log15.Logger, and if it will be pointed to a real file,
+// it installs a SIGHUP handler that will atomically reopen the file and
+// redirect all future logging operations.
+func New(level string, json bool) (logging.Logger, error) {
+	l := log.New()
+	var handler log.Handler
+	if json {
+		handler = log.StreamHandler(os.Stderr, log.JsonFormat())
+	} else {
+		handler = log.StderrHandler
+	}
+
+	// Don't log things that are chattier than level, but for errors also
+	// include the stack trace.
+	maxLvl, err := log.LvlFromString(level)
+	if err != nil {
+		return nil, err
+	}
+	l.SetHandler(errorCallerStackHandler(maxLvl, handler))
+	return Wrap(l), nil
+}
+
+func rootCauseStackTrace(err error) errors.StackTrace {
+	type causer interface {
+		Cause() error
+	}
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+
+	var deepestStackTrace errors.StackTrace
+
+	for err != nil {
+		if stackTrace, ok := err.(stackTracer); ok {
+			deepestStackTrace = stackTrace.StackTrace()
+		}
+
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return deepestStackTrace
+}
+
+// errorCallerStackHandler creates a handler that drops all logs that are less
+// important than maxLvl, and also adds a stack trace to all events that are
+// errors / critical, as well as the error values that have a stack trace.
+func errorCallerStackHandler(maxLvl log.Lvl, handler log.Handler) log.Handler {
+	callerStackHandler := log.FuncHandler(func(r *log.Record) error {
+		// Get the stack trace of the call to log.Error/log.Crit.
+		s := stack.Trace().TrimBelow(r.Call).TrimRuntime()
+		if len(s) > 0 {
+			var buf bytes.Buffer
+
+			buf.WriteString("[")
+			for i, pc := range s {
+				if i > 0 {
+					buf.WriteString(" ")
+				}
+				fmt.Fprintf(&buf, "%+n(%+v)", pc, pc)
+			}
+			buf.WriteString("]")
+
+			r.Ctx = append(r.Ctx, "stack", buf.String())
+		}
+
+		// Get the stack trace of the first error value.
+		for i := 1; i < len(r.Ctx); i += 2 {
+			err, ok := r.Ctx[i].(error)
+			if !ok {
+				continue
+			}
+
+			stackTrace := rootCauseStackTrace(err)
+			if stackTrace == nil {
+				continue
+			}
+
+			r.Ctx = append(r.Ctx, "errstack", fmt.Sprintf("%+v", stackTrace))
+			break
+		}
+
+		return handler.Log(r)
+	})
+	return log.FuncHandler(func(r *log.Record) error {
+		if r.Lvl > maxLvl {
+			return nil
+		}
+		if r.Lvl <= log.LvlError {
+			return callerStackHandler.Log(r)
+		}
+		return handler.Log(r)
+	})
+}


### PR DESCRIPTION
This should allow us to remove any and all references to log15
everywhere. Slowly start to move towards zap at some point.