### PR TITLE
Add two more logging utility classes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	github.com/pkg/errors v0.8.1
 	golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab // indirect
 )
+
+require github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec h1:CGkYB1Q7DSsH/ku+to+foV4agt2F2miquaLUgF6L178=

--- a/logging/log15/log15.go
+++ b/logging/log15/log15.go
@@ -23,19 +23,35 @@ func Wrap(l log.Logger) logging.Logger {
 	return &log15Logger{l: l}
 }
 
+func (l *log15Logger) New(context map[string]interface{}) logging.Logger {
+	return &log15Logger{l: l.l.New(log.Ctx(context))}
+}
+
 func (l *log15Logger) Error(msg string, context map[string]interface{}) {
+	if l == nil {
+		return
+	}
 	l.l.Error(msg, log.Ctx(context))
 }
 
 func (l *log15Logger) Warn(msg string, context map[string]interface{}) {
+	if l == nil {
+		return
+	}
 	l.l.Warn(msg, log.Ctx(context))
 }
 
 func (l *log15Logger) Info(msg string, context map[string]interface{}) {
+	if l == nil {
+		return
+	}
 	l.l.Info(msg, log.Ctx(context))
 }
 
 func (l *log15Logger) Debug(msg string, context map[string]interface{}) {
+	if l == nil {
+		return
+	}
 	l.l.Debug(msg, log.Ctx(context))
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,10 +1,153 @@
 package logging
 
+import (
+	"io"
+	"time"
+
+	"github.com/go-logfmt/logfmt"
+)
+
 // Logger is an interface compatible with newrelic.Logger
 type Logger interface {
+	New(context map[string]interface{}) Logger
 	Error(msg string, context map[string]interface{})
 	Warn(msg string, context map[string]interface{})
 	Info(msg string, context map[string]interface{})
 	Debug(msg string, context map[string]interface{})
 	DebugEnabled() bool
+}
+
+func mergeContexts(a, b map[string]interface{}) map[string]interface{} {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	newContext := make(map[string]interface{}, len(a)+len(b))
+	for k, v := range a {
+		newContext[k] = v
+	}
+	for k, v := range b {
+		newContext[k] = v
+	}
+	return newContext
+}
+
+type multiLogger struct {
+	l       []Logger
+	context map[string]interface{}
+}
+
+// NewMultiLogger returns a composed Logger that forwards all calls to all
+// provided Loggers.
+func NewMultiLogger(l ...Logger) Logger {
+	return &multiLogger{l: l}
+}
+
+func (l *multiLogger) New(context map[string]interface{}) Logger {
+	return &multiLogger{l: l.l, context: mergeContexts(l.context, context)}
+}
+
+func (l *multiLogger) Error(msg string, context map[string]interface{}) {
+	newContext := mergeContexts(l.context, context)
+	for _, ll := range l.l {
+		ll.Error(msg, newContext)
+	}
+}
+
+func (l *multiLogger) Warn(msg string, context map[string]interface{}) {
+	newContext := mergeContexts(l.context, context)
+	for _, ll := range l.l {
+		ll.Warn(msg, newContext)
+	}
+}
+
+func (l *multiLogger) Info(msg string, context map[string]interface{}) {
+	newContext := mergeContexts(l.context, context)
+	for _, ll := range l.l {
+		ll.Info(msg, newContext)
+	}
+}
+
+func (l *multiLogger) Debug(msg string, context map[string]interface{}) {
+	newContext := mergeContexts(l.context, context)
+	for _, ll := range l.l {
+		ll.Debug(msg, newContext)
+	}
+}
+
+func (l *multiLogger) DebugEnabled() bool {
+	for _, ll := range l.l {
+		if ll.DebugEnabled() {
+			return true
+		}
+	}
+	return false
+}
+
+type inMemoryLogfmtLogger struct {
+	w       *logfmt.Encoder
+	context map[string]interface{}
+}
+
+// NewInMemoryLogfmtLogger writes logfmt-formatted records to the provided writer.
+func NewInMemoryLogfmtLogger(w io.Writer) Logger {
+	return &inMemoryLogfmtLogger{w: logfmt.NewEncoder(w)}
+}
+
+func (l *inMemoryLogfmtLogger) New(context map[string]interface{}) Logger {
+	return &inMemoryLogfmtLogger{w: l.w, context: mergeContexts(l.context, context)}
+}
+
+func (l *inMemoryLogfmtLogger) Error(msg string, context map[string]interface{}) {
+	l.w.EncodeKeyvals(
+		"t", time.Now().Format(time.RFC3339),
+		"lvl", "eror",
+		"msg", msg,
+	)
+	for k, v := range mergeContexts(l.context, context) {
+		l.w.EncodeKeyval(k, v)
+	}
+	l.w.EndRecord()
+}
+
+func (l *inMemoryLogfmtLogger) Warn(msg string, context map[string]interface{}) {
+	l.w.EncodeKeyvals(
+		"t", time.Now().Format(time.RFC3339),
+		"lvl", "warn",
+		"msg", msg,
+	)
+	for k, v := range mergeContexts(l.context, context) {
+		l.w.EncodeKeyval(k, v)
+	}
+	l.w.EndRecord()
+}
+
+func (l *inMemoryLogfmtLogger) Info(msg string, context map[string]interface{}) {
+	l.w.EncodeKeyvals(
+		"t", time.Now().Format(time.RFC3339),
+		"lvl", "info",
+		"msg", msg,
+	)
+	for k, v := range mergeContexts(l.context, context) {
+		l.w.EncodeKeyval(k, v)
+	}
+	l.w.EndRecord()
+}
+
+func (l *inMemoryLogfmtLogger) Debug(msg string, context map[string]interface{}) {
+	l.w.EncodeKeyvals(
+		"t", time.Now().Format(time.RFC3339),
+		"lvl", "dbug",
+		"msg", msg,
+	)
+	for k, v := range mergeContexts(l.context, context) {
+		l.w.EncodeKeyval(k, v)
+	}
+	l.w.EndRecord()
+}
+
+func (l *inMemoryLogfmtLogger) DebugEnabled() bool {
+	return true
 }


### PR DESCRIPTION
This change adds:

* NewMultiLogger, that composes multiple Loggers into one.
* NewInMemoryLogfmtLogger, that stores logs into an io.Writer.
* The New() function to the Logger interface, to be able to create
  logging sub-contexts.

This is a #minor change, and the last in the v2 version. The next will
be an API-breaking change.