### PR TITLE
Fix error logging

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -57,7 +57,7 @@ func ErrorWithCategory(category error, cause error) error {
 }
 
 func (c *withCategory) Error() string {
-	return fmt.Sprintf("%s: %s", c.category.Error(), c.cause.Error())
+	return fmt.Sprintf("%v: %v", c.category, c.cause)
 }
 
 func (c *withCategory) Cause() error { return c.cause }

--- a/logging/log15/log15.go
+++ b/logging/log15/log15.go
@@ -122,7 +122,10 @@ func rootCauseStackTrace(err error) errors.StackTrace {
 
 	for err != nil {
 		if stackTrace, ok := err.(stackTracer); ok {
-			deepestStackTrace = stackTrace.StackTrace()
+			s := stackTrace.StackTrace()
+			if len(s) > 0 {
+				deepestStackTrace = s
+			}
 		}
 
 		cause, ok := err.(causer)


### PR DESCRIPTION
At some point, error logging got a bit messed up: the error message was
not being displayed correctly, and the error stack trace was not showing
up at all.

This change should fix that.