### PR TITLE
Correctly add metadata to the loggers

### DIFF
--- a/tracing/newrelic/newrelic.go
+++ b/tracing/newrelic/newrelic.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"net/http"
 
+	"github.com/omegaup/go-base/v3/logging"
 	"github.com/omegaup/go-base/v3/tracing"
 
 	nr "github.com/newrelic/go-agent/v3/newrelic"
@@ -50,6 +51,26 @@ func (p *provider) WrapHandle(pattern string, handler http.Handler) (string, htt
 
 type transaction struct {
 	txn *nr.Transaction
+}
+
+func (t *transaction) WithMetadata(log logging.Logger) logging.Logger {
+	lm := t.txn.GetLinkingMetadata()
+	context := make(map[string]interface{}, 6)
+	addField := func(key, val string) {
+		if val == "" {
+			return
+		}
+		context[key] = val
+	}
+	// These constants come from
+	// https://pkg.go.dev/github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin
+	addField("trace.id", lm.TraceID)
+	addField("span.id", lm.SpanID)
+	addField("entity.name", lm.EntityName)
+	addField("entity.type", lm.EntityType)
+	addField("entity.guid", lm.EntityGUID)
+	addField("hostname", lm.Hostname)
+	return log.New(context)
 }
 
 func (t *transaction) SetName(name string) {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -3,6 +3,8 @@ package tracing
 import (
 	"context"
 	"net/http"
+
+	"github.com/omegaup/go-base/v3/logging"
 )
 
 type key int
@@ -25,6 +27,9 @@ type Segment interface {
 // A Transaction represents one logical unit of work: either an
 // inbound web request or background task.
 type Transaction interface {
+	// WithMetadata wraps the logger with the transaction metadata.
+	WithMetadata(log logging.Logger) logging.Logger
+
 	// SetName sets the current transaction's name.
 	SetName(name string)
 
@@ -107,6 +112,9 @@ func NewNoOpTransaction() Transaction {
 	return &noopTransaction{}
 }
 
+func (t *noopTransaction) WithMetadata(log logging.Logger) logging.Logger {
+	return log
+}
 func (t *noopTransaction) SetName(name string)       {}
 func (t *noopTransaction) AddAttributes(args ...Arg) {}
 func (t *noopTransaction) StartSegment(name string) Segment {


### PR DESCRIPTION
This change makes it possible to now correctly add the necessary
metadata to the loggers. Previously it wasn't being done correctly
because we were registering this module's Transaction into the context,
whereas the logging module depended on the New Relic Transaction.