### PR TITLE
Tweak the LRU cache interface

### DIFF
--- a/lru_cache_test.go
+++ b/lru_cache_test.go
@@ -23,10 +23,6 @@ func (r *releasable) Size() Byte {
 	return r.size
 }
 
-func (r *releasable) Value() *releasable {
-	return r
-}
-
 func TestLRUCache(t *testing.T) {
 	c := NewLRUCache[*releasable](Kibibyte)
 
@@ -47,7 +43,7 @@ func TestLRUCache(t *testing.T) {
 	// New object is created.
 	{
 		created := false
-		ref, err := c.Get("r", func(key string) (SizedEntry[*releasable], error) {
+		ref, err := c.Get("r", func(key string) (*releasable, error) {
 			created = true
 			return &r, nil
 		})
@@ -93,7 +89,7 @@ func TestLRUCache(t *testing.T) {
 	// Object is reused.
 	{
 		created := false
-		ref, err := c.Get("r", func(key string) (SizedEntry[*releasable], error) {
+		ref, err := c.Get("r", func(key string) (*releasable, error) {
 			created = true
 			return &r, nil
 		})
@@ -139,7 +135,7 @@ func TestLRUCache(t *testing.T) {
 	// New object is created, old one is evicted.
 	{
 		created := false
-		ref, err := c.Get("r1k", func(key string) (SizedEntry[*releasable], error) {
+		ref, err := c.Get("r1k", func(key string) (*releasable, error) {
 			created = true
 			return &r1k, nil
 		})
@@ -188,7 +184,7 @@ func TestLRUCache(t *testing.T) {
 	// New object is created, and evicted immediately upon release.
 	{
 		created := false
-		ref, err := c.Get("r1M", func(key string) (SizedEntry[*releasable], error) {
+		ref, err := c.Get("r1M", func(key string) (*releasable, error) {
 			created = true
 			return &r1M, nil
 		})


### PR DESCRIPTION
It turns out that the SizedEntry doesn't need to _have_ a value, since it often _is_ the value.

This change makes it such that the SizedEntry is now the constraint of what the LRUCache holds.