### PR TITLE
Allow nil rationals to still be converted to floats

### DIFF
--- a/rational.go
+++ b/rational.go
@@ -73,6 +73,9 @@ func FloatToRational(floatVal float64) *big.Rat {
 
 // RationalToFloat returns the closest float value to the given big.Rat.
 func RationalToFloat(val *big.Rat) float64 {
+	if val == nil {
+		return 0
+	}
 	floatVal, _ := val.Float64()
 	return floatVal
 }


### PR DESCRIPTION
This change allows `RationalToFloat((*big.Rat)(nil))` to return zero instead of panicking.